### PR TITLE
Add dummy Salus Home Assistant integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,14 @@
 !sandbox.py
 !.gitignore
 !README.md
+!hacs.json
+!custom_components/
+!custom_components/salus/
+!custom_components/salus/**
 
 # Always ignore the SALUS folder and everything inside it
 SALUS/
+
+# Ignore test cache
+.pytest_cache/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Salus Home Assistant Integration
+
+This custom integration provides a dummy Salus thermostat for Home Assistant. It exposes:
+
+- Room temperature sensor
+- Target temperature sensor
+- Thermostat entity with `auto` and `off` modes
+
+The integration does not communicate with any real devices and is intended as a starting point for further development.
+
+## Installation
+
+1. Add this repository to HACS as a custom repository.
+2. Install the **Salus** integration from HACS.
+3. Add `salus:` to your `configuration.yaml` and restart Home Assistant.

--- a/custom_components/salus/__init__.py
+++ b/custom_components/salus/__init__.py
@@ -1,0 +1,35 @@
+"""Salus integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.climate.const import HVACMode
+
+DOMAIN = "salus"
+
+
+class SalusDevice:
+    """Dummy device holding the Salus thermostat state."""
+
+    def __init__(self) -> None:
+        self.room_temperature: float = 20.0
+        self.target_temperature: float = 22.0
+        self.hvac_mode: HVACMode = HVACMode.AUTO
+        self._listeners: list[callable] = []
+
+    def register_listener(self, callback) -> None:
+        """Register a callback to be notified on state changes."""
+        self._listeners.append(callback)
+
+    def _notify(self) -> None:
+        for callback in self._listeners:
+            callback()
+
+
+async def async_setup(hass, config):
+    """Set up the Salus integration."""
+    device = SalusDevice()
+    hass.data[DOMAIN] = device
+
+    hass.helpers.discovery.load_platform("climate", DOMAIN, {}, config)
+    hass.helpers.discovery.load_platform("sensor", DOMAIN, {}, config)
+    return True

--- a/custom_components/salus/climate.py
+++ b/custom_components/salus/climate.py
@@ -1,0 +1,52 @@
+"""Salus climate platform."""
+
+from __future__ import annotations
+
+from homeassistant.components.climate import ClimateEntity, ClimateEntityFeature
+from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
+
+from . import DOMAIN, SalusDevice
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the Salus climate entity."""
+    device: SalusDevice = hass.data[DOMAIN]
+    entity = SalusThermostat(device)
+    async_add_entities([entity])
+
+
+class SalusThermostat(ClimateEntity):
+    """Representation of a dummy Salus thermostat."""
+
+    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+    _attr_hvac_modes = [HVACMode.AUTO, HVACMode.OFF]
+    _attr_name = "Salus Thermostat"
+
+    def __init__(self, device: SalusDevice) -> None:
+        self._device = device
+
+    async def async_added_to_hass(self) -> None:
+        self._device.register_listener(self.async_write_ha_state)
+
+    @property
+    def hvac_mode(self) -> HVACMode:
+        return self._device.hvac_mode
+
+    @property
+    def current_temperature(self) -> float:
+        return self._device.room_temperature
+
+    @property
+    def target_temperature(self) -> float:
+        return self._device.target_temperature
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        self._device.hvac_mode = hvac_mode
+        self._device._notify()
+
+    async def async_set_temperature(self, **kwargs) -> None:
+        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is not None:
+            self._device.target_temperature = temperature
+            self._device._notify()

--- a/custom_components/salus/manifest.json
+++ b/custom_components/salus/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "salus",
+  "name": "Salus",
+  "version": "0.1.0",
+  "documentation": "https://github.com/user/salus-ha",
+  "requirements": [],
+  "codeowners": ["@user"],
+  "iot_class": "local_polling"
+}

--- a/custom_components/salus/sensor.py
+++ b/custom_components/salus/sensor.py
@@ -1,0 +1,52 @@
+"""Salus sensor platform."""
+
+from __future__ import annotations
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import TEMP_CELSIUS
+
+from . import DOMAIN, SalusDevice
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up Salus sensors."""
+    device: SalusDevice = hass.data[DOMAIN]
+    sensors: list[SensorEntity] = [
+        SalusRoomTemperatureSensor(device),
+        SalusTargetTemperatureSensor(device),
+    ]
+    async_add_entities(sensors)
+
+
+class SalusRoomTemperatureSensor(SensorEntity):
+    """Sensor for the room temperature."""
+
+    _attr_name = "Salus Room Temperature"
+    _attr_native_unit_of_measurement = TEMP_CELSIUS
+
+    def __init__(self, device: SalusDevice) -> None:
+        self._device = device
+
+    async def async_added_to_hass(self) -> None:
+        self._device.register_listener(self.async_write_ha_state)
+
+    @property
+    def native_value(self) -> float:
+        return self._device.room_temperature
+
+
+class SalusTargetTemperatureSensor(SensorEntity):
+    """Sensor for the target temperature."""
+
+    _attr_name = "Salus Target Temperature"
+    _attr_native_unit_of_measurement = TEMP_CELSIUS
+
+    def __init__(self, device: SalusDevice) -> None:
+        self._device = device
+
+    async def async_added_to_hass(self) -> None:
+        self._device.register_listener(self.async_write_ha_state)
+
+    @property
+    def native_value(self) -> float:
+        return self._device.target_temperature

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "Salus",
+  "domain": "salus",
+  "homeassistant": "2023.1.0",
+  "render_readme": true
+}


### PR DESCRIPTION
## Summary
- Add basic Salus custom integration with climate and temperature sensors
- Provide HACS metadata and documentation for installation

## Testing
- `python -m py_compile custom_components/salus/*.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c57e063c1c832a97a9c6a9a47c2751