### PR TITLE
Load Salus platforms asynchronously

### DIFF
--- a/custom_components/salus/__init__.py
+++ b/custom_components/salus/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.helpers.discovery import async_load_platform
 
 DOMAIN = "salus"
 
@@ -30,6 +31,10 @@ async def async_setup(hass, config):
     device = SalusDevice()
     hass.data[DOMAIN] = device
 
-    hass.helpers.discovery.load_platform("climate", DOMAIN, {}, config)
-    hass.helpers.discovery.load_platform("sensor", DOMAIN, {}, config)
+    hass.async_create_task(
+        async_load_platform(hass, "climate", DOMAIN, {}, config)
+    )
+    hass.async_create_task(
+        async_load_platform(hass, "sensor", DOMAIN, {}, config)
+    )
     return True


### PR DESCRIPTION
## Summary
- use `async_load_platform` to schedule climate and sensor platform loading

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5868b755c832aa5a69a85f51bafe4