### PR TITLE
Add username/password configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,10 @@ The integration does not communicate with any real devices and is intended as a 
 
 1. Add this repository to HACS as a custom repository.
 2. Install the **Salus** integration from HACS.
-3. Add `salus:` to your `configuration.yaml` and restart Home Assistant.
+3. Add the integration to your `configuration.yaml` with credentials and restart Home Assistant:
+
+   ```yaml
+   salus:
+     username: YOUR_USERNAME
+     password: YOUR_PASSWORD
+   ```

--- a/custom_components/salus/__init__.py
+++ b/custom_components/salus/__init__.py
@@ -3,9 +3,25 @@
 from __future__ import annotations
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.discovery import async_load_platform
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
 
 DOMAIN = "salus"
+
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_USERNAME): cv.string,
+                vol.Required(CONF_PASSWORD): cv.string,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
 
 
 class SalusDevice:
@@ -28,8 +44,16 @@ class SalusDevice:
 
 async def async_setup(hass, config):
     """Set up the Salus integration."""
+    conf = config[DOMAIN]
+    username = conf[CONF_USERNAME]
+    password = conf[CONF_PASSWORD]
+
     device = SalusDevice()
-    hass.data[DOMAIN] = device
+    hass.data[DOMAIN] = {
+        "device": device,
+        "username": username,
+        "password": password,
+    }
 
     hass.async_create_task(
         async_load_platform(hass, "climate", DOMAIN, {}, config)

--- a/custom_components/salus/climate.py
+++ b/custom_components/salus/climate.py
@@ -11,7 +11,7 @@ from . import DOMAIN, SalusDevice
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Salus climate entity."""
-    device: SalusDevice = hass.data[DOMAIN]
+    device: SalusDevice = hass.data[DOMAIN]["device"]
     entity = SalusThermostat(device)
     async_add_entities([entity])
 


### PR DESCRIPTION
## Summary
- add username and password config options for Salus integration
- document credentials in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c582c80004832abbb0b9403ddf0a1d