### PR TITLE
Add logging and debug instructions to Salus integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,15 @@ The integration does not communicate with any real devices and is intended as a 
      username: YOUR_USERNAME
      password: YOUR_PASSWORD
    ```
+
+## Debug Logging
+
+To enable debug logging for this integration, add the following to your `configuration.yaml`:
+
+```yaml
+logger:
+  default: info
+  logs:
+    custom_components.salus: debug
+```
+

--- a/custom_components/salus/__init__.py
+++ b/custom_components/salus/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.discovery import async_load_platform
@@ -9,6 +11,9 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 
 DOMAIN = "salus"
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 CONFIG_SCHEMA = vol.Schema(
@@ -48,6 +53,9 @@ async def async_setup(hass, config):
     username = conf[CONF_USERNAME]
     password = conf[CONF_PASSWORD]
 
+    _LOGGER.info("Setting up Salus integration")
+    _LOGGER.debug("Configuration username: %s", username)
+
     device = SalusDevice()
     hass.data[DOMAIN] = {
         "device": device,
@@ -55,10 +63,12 @@ async def async_setup(hass, config):
         "password": password,
     }
 
+    _LOGGER.debug("Creating Salus platforms")
     hass.async_create_task(
         async_load_platform(hass, "climate", DOMAIN, {}, config)
     )
     hass.async_create_task(
         async_load_platform(hass, "sensor", DOMAIN, {}, config)
     )
+    _LOGGER.info("Salus integration setup complete")
     return True

--- a/custom_components/salus/climate.py
+++ b/custom_components/salus/climate.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.components.climate import ClimateEntity, ClimateEntityFeature
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
@@ -9,8 +11,12 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from . import DOMAIN, SalusDevice
 
 
+_LOGGER = logging.getLogger(__name__)
+
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Salus climate entity."""
+    _LOGGER.info("Setting up Salus climate entity")
     device: SalusDevice = hass.data[DOMAIN]["device"]
     entity = SalusThermostat(device)
     async_add_entities([entity])
@@ -43,10 +49,12 @@ class SalusThermostat(ClimateEntity):
         return self._device.target_temperature
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        _LOGGER.info("Setting HVAC mode to %s", hvac_mode)
         self._device.hvac_mode = hvac_mode
         self._device._notify()
 
     async def async_set_temperature(self, **kwargs) -> None:
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is not None:
+            _LOGGER.info("Setting target temperature to %s", temperature)
             self._device.target_temperature = temperature
             self._device._notify()

--- a/custom_components/salus/sensor.py
+++ b/custom_components/salus/sensor.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import UnitOfTemperature
 
 
+_LOGGER = logging.getLogger(__name__)
+
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Salus room temperature sensor."""
+    _LOGGER.info("Setting up Salus room temperature sensor")
     async_add_entities([SalusRoomTemperatureSensor()])
 
 
@@ -20,4 +26,6 @@ class SalusRoomTemperatureSensor(SensorEntity):
     @property
     def native_value(self) -> float:
         """Return a constant room temperature."""
-        return 23.0
+        temperature = 23.0
+        _LOGGER.debug("Reporting room temperature %s", temperature)
+        return temperature

--- a/salus.py
+++ b/salus.py
@@ -7,8 +7,11 @@
 # The security token is requested for each operation
 
 from dataclasses import dataclass
+import logging
 import requests
 from html.parser import HTMLParser
+
+_LOGGER = logging.getLogger(__name__)
 
 # Salus Device Class
 @dataclass
@@ -160,14 +163,16 @@ class Salus:
     def check_device_battery(self, device_id):
         url = 'https://salus-it500.com/ota/battery_check.php'  # Adjust the URL as per your server
         params = {'devId': device_id}
-        
+
+        _LOGGER.debug("Checking battery for device %s", device_id)
         try:
             response = self.session.get(url, params=params)
             response.raise_for_status()  # Raise an exception for HTTP errors
             battery_data = response.json()  # Assuming the response is in JSON format
+            _LOGGER.debug("Received battery data: %s", battery_data)
             return battery_data
         except requests.exceptions.RequestException as e:
-            print(f"Error while checking battery: {e}")
+            _LOGGER.error("Error while checking battery: %s", e)
             return None
         
     # Check login responce status. that function checks responce after login and try to find the block with error message


### PR DESCRIPTION
## Summary
- add structured logging across Salus integration modules
- replace print in battery check with logger error
- document enabling debug logging via configuration.yaml

## Testing
- `pytest`
- `python -m py_compile custom_components/salus/__init__.py custom_components/salus/climate.py custom_components/salus/sensor.py salus.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5c4306450832aadaabbc47632d3e1