### PR TITLE
feat: add explicit heat/off modes for thermostat

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This custom integration provides a dummy Salus thermostat for Home Assistant. It
 
 - Room temperature sensor (returns a constant value of 23°C)
 - Target temperature sensor
-- Thermostat entity with `auto` and `off` modes
+- Thermostat entity with `heat` and `off` modes
 
 The integration does not communicate with any real devices and is intended as a starting point for further development.
 

--- a/custom_components/salus/__init__.py
+++ b/custom_components/salus/__init__.py
@@ -35,7 +35,7 @@ class SalusDevice:
     def __init__(self) -> None:
         self.room_temperature: float = 20.0
         self.target_temperature: float = 22.0
-        self.hvac_mode: HVACMode = HVACMode.AUTO
+        self.hvac_mode: HVACMode = HVACMode.HEAT
         self._listeners: list[callable] = []
 
     def register_listener(self, callback) -> None:

--- a/custom_components/salus/climate.py
+++ b/custom_components/salus/climate.py
@@ -27,7 +27,7 @@ class SalusThermostat(ClimateEntity):
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
-    _attr_hvac_modes = [HVACMode.AUTO, HVACMode.OFF]
+    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
     _attr_name = "Salus Thermostat"
 
     def __init__(self, device: SalusDevice) -> None:


### PR DESCRIPTION
## Summary
- limit HVAC modes to heat and off
- default device to heat mode
- update README example

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5d28f9420832ab8abfa5c80ab16cf