### PR TITLE
Add dummy device list support

### DIFF
--- a/custom_components/salus/__init__.py
+++ b/custom_components/salus/__init__.py
@@ -32,7 +32,9 @@ CONFIG_SCHEMA = vol.Schema(
 class SalusDevice:
     """Dummy device holding the Salus thermostat state."""
 
-    def __init__(self) -> None:
+    def __init__(self, device_id: str, name: str) -> None:
+        self.id = device_id
+        self.name = name
         self.room_temperature: float = 20.0
         self.target_temperature: float = 22.0
         self.hvac_mode: HVACMode = HVACMode.HEAT
@@ -56,9 +58,15 @@ async def async_setup(hass, config):
     _LOGGER.info("Setting up Salus integration")
     _LOGGER.debug("Configuration username: %s", username)
 
-    device = SalusDevice()
+    devices = [
+        SalusDevice("device_1", "Salus Device 1"),
+        SalusDevice("device_2", "Salus Device 2"),
+        SalusDevice("device_3", "Salus Device 3"),
+        SalusDevice("device_4", "Salus Device 4"),
+    ]
+
     hass.data[DOMAIN] = {
-        "device": device,
+        "devices": devices,
         "username": username,
         "password": password,
     }

--- a/custom_components/salus/climate.py
+++ b/custom_components/salus/climate.py
@@ -17,9 +17,9 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Salus climate entity."""
     _LOGGER.info("Setting up Salus climate entity")
-    device: SalusDevice = hass.data[DOMAIN]["device"]
-    entity = SalusThermostat(device)
-    async_add_entities([entity])
+    devices: list[SalusDevice] = hass.data[DOMAIN]["devices"]
+    entities = [SalusThermostat(device) for device in devices]
+    async_add_entities(entities)
 
 
 class SalusThermostat(ClimateEntity):
@@ -28,10 +28,14 @@ class SalusThermostat(ClimateEntity):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
     _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
-    _attr_name = "Salus Thermostat"
 
     def __init__(self, device: SalusDevice) -> None:
         self._device = device
+        self._attr_name = device.name
+
+    @property
+    def unique_id(self) -> str:
+        return self._device.id
 
     async def async_added_to_hass(self) -> None:
         self._device.register_listener(self.async_write_ha_state)

--- a/custom_components/salus/sensor.py
+++ b/custom_components/salus/sensor.py
@@ -7,25 +7,40 @@ import logging
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import UnitOfTemperature
 
+from . import DOMAIN, SalusDevice
+
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up the Salus room temperature sensor."""
-    _LOGGER.info("Setting up Salus room temperature sensor")
-    async_add_entities([SalusRoomTemperatureSensor()])
+    """Set up the Salus room temperature sensors."""
+    _LOGGER.info("Setting up Salus room temperature sensors")
+    devices: list[SalusDevice] = hass.data[DOMAIN]["devices"]
+    sensors = [SalusRoomTemperatureSensor(device) for device in devices]
+    async_add_entities(sensors)
 
 
 class SalusRoomTemperatureSensor(SensorEntity):
     """Dummy sensor for the room temperature."""
 
-    _attr_name = "Salus Room Temperature"
-    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    def __init__(self, device: SalusDevice) -> None:
+        self._device = device
+        self._attr_name = f"{device.name} Room Temperature"
+        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+
+    async def async_added_to_hass(self) -> None:
+        self._device.register_listener(self.async_write_ha_state)
 
     @property
     def native_value(self) -> float:
-        """Return a constant room temperature."""
-        temperature = 23.0
-        _LOGGER.debug("Reporting room temperature %s", temperature)
+        """Return the device room temperature."""
+        temperature = self._device.room_temperature
+        _LOGGER.debug(
+            "Reporting room temperature %s for %s", temperature, self._device.name
+        )
         return temperature
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._device.id}_temperature"


### PR DESCRIPTION
## Summary
- support multiple devices by creating 4 dummy devices
- expose each device as climate and sensor entities with unique IDs

## Testing
- `python -m py_compile custom_components/salus/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5d4510544832abf2e1f608f967cf6