### PR TITLE
Add config flow and device registry for Salus

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,8 @@ The integration does not communicate with any real devices and is intended as a 
 
 1. Add this repository to HACS as a custom repository.
 2. Install the **Salus** integration from HACS.
-3. Add the integration to your `configuration.yaml` with credentials and restart Home Assistant:
-
-   ```yaml
-   salus:
-     username: YOUR_USERNAME
-     password: YOUR_PASSWORD
-   ```
+3. Add the integration via **Settings → Devices & Services** in Home Assistant and
+   enter your Salus username and password when prompted.
 
 ## Debug Logging
 

--- a/custom_components/salus/climate.py
+++ b/custom_components/salus/climate.py
@@ -7,6 +7,7 @@ import logging
 from homeassistant.components.climate import ClimateEntity, ClimateEntityFeature
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.helpers.device_registry import DeviceInfo
 
 from . import DOMAIN, SalusDevice
 
@@ -14,10 +15,11 @@ from . import DOMAIN, SalusDevice
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up the Salus climate entity."""
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up Salus climate entities from config entry."""
     _LOGGER.info("Setting up Salus climate entity")
-    devices: list[SalusDevice] = hass.data[DOMAIN]["devices"]
+    data = hass.data[DOMAIN][entry.entry_id]
+    devices: list[SalusDevice] = data["devices"]
     entities = [SalusThermostat(device) for device in devices]
     async_add_entities(entities)
 
@@ -32,6 +34,11 @@ class SalusThermostat(ClimateEntity):
     def __init__(self, device: SalusDevice) -> None:
         self._device = device
         self._attr_name = device.name
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.id)},
+            name=device.name,
+            manufacturer="Salus",
+        )
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/salus/config_flow.py
+++ b/custom_components/salus/config_flow.py
@@ -1,0 +1,28 @@
+"""Config flow for Salus integration."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from . import DOMAIN
+
+
+class SalusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Salus."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict | None = None):
+        """Handle the initial step."""
+        if user_input is not None:
+            return self.async_create_entry(title="Salus", data=user_input)
+
+        data_schema = vol.Schema({
+            vol.Required(CONF_USERNAME): str,
+            vol.Required(CONF_PASSWORD): str,
+        })
+
+        return self.async_show_form(step_id="user", data_schema=data_schema)

--- a/custom_components/salus/manifest.json
+++ b/custom_components/salus/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "salus",
   "name": "Salus",
+  "config_flow": true,
   "version": "0.1.0",
   "documentation": "https://github.com/user/salus-ha",
   "requirements": [],

--- a/custom_components/salus/sensor.py
+++ b/custom_components/salus/sensor.py
@@ -6,6 +6,7 @@ import logging
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import UnitOfTemperature
+from homeassistant.helpers.device_registry import DeviceInfo
 
 from . import DOMAIN, SalusDevice
 
@@ -13,10 +14,11 @@ from . import DOMAIN, SalusDevice
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up the Salus room temperature sensors."""
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the Salus room temperature sensors from config entry."""
     _LOGGER.info("Setting up Salus room temperature sensors")
-    devices: list[SalusDevice] = hass.data[DOMAIN]["devices"]
+    data = hass.data[DOMAIN][entry.entry_id]
+    devices: list[SalusDevice] = data["devices"]
     sensors = [SalusRoomTemperatureSensor(device) for device in devices]
     async_add_entities(sensors)
 
@@ -28,6 +30,11 @@ class SalusRoomTemperatureSensor(SensorEntity):
         self._device = device
         self._attr_name = f"{device.name} Room Temperature"
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.id)},
+            name=device.name,
+            manufacturer="Salus",
+        )
 
     async def async_added_to_hass(self) -> None:
         self._device.register_listener(self.async_write_ha_state)


### PR DESCRIPTION
## Summary
- enable UI-based configuration by adding a config flow and config entry setup
- register dummy devices in the device registry so devices appear in the integration page
- document UI setup in README

## Testing
- `python -m py_compile custom_components/salus/__init__.py custom_components/salus/config_flow.py custom_components/salus/climate.py custom_components/salus/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5d5c2f1a4832ab28c1d813554cba2