### PR TITLE
Fix device grouping for Salus entities

### DIFF
--- a/custom_components/salus/climate.py
+++ b/custom_components/salus/climate.py
@@ -37,6 +37,15 @@ class SalusThermostat(ClimateEntity):
     def unique_id(self) -> str:
         return self._device.id
 
+    @property
+    def device_info(self) -> dict:
+        """Return device information for this thermostat."""
+        return {
+            "identifiers": {(DOMAIN, self._device.id)},
+            "name": self._device.name,
+            "manufacturer": "Salus",
+        }
+
     async def async_added_to_hass(self) -> None:
         self._device.register_listener(self.async_write_ha_state)
 

--- a/custom_components/salus/sensor.py
+++ b/custom_components/salus/sensor.py
@@ -44,3 +44,12 @@ class SalusRoomTemperatureSensor(SensorEntity):
     @property
     def unique_id(self) -> str:
         return f"{self._device.id}_temperature"
+
+    @property
+    def device_info(self) -> dict:
+        """Return device information for this sensor."""
+        return {
+            "identifiers": {(DOMAIN, self._device.id)},
+            "name": self._device.name,
+            "manufacturer": "Salus",
+        }


### PR DESCRIPTION
## Summary
- link climate and sensor entities to their devices so counts show correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5d8cd4f44832a8e8166ba7bf8b38d