### PR TITLE
Add config entry support and device registration

### DIFF
--- a/custom_components/salus/climate.py
+++ b/custom_components/salus/climate.py
@@ -14,10 +14,10 @@ from . import DOMAIN, SalusDevice
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up the Salus climate entity."""
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the Salus climate entity from a config entry."""
     _LOGGER.info("Setting up Salus climate entity")
-    devices: list[SalusDevice] = hass.data[DOMAIN]["devices"]
+    devices: list[SalusDevice] = hass.data[DOMAIN][entry.entry_id]["devices"]
     entities = [SalusThermostat(device) for device in devices]
     async_add_entities(entities)
 

--- a/custom_components/salus/config_flow.py
+++ b/custom_components/salus/config_flow.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from . import DOMAIN
+
+
+class SalusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for the Salus integration."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict | None = None):
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            return self.async_create_entry(title="Salus", data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_USERNAME): str,
+                vol.Required(CONF_PASSWORD): str,
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
+
+    async def async_step_import(self, user_input: dict):
+        """Handle import from configuration.yaml."""
+        return await self.async_step_user(user_input)

--- a/custom_components/salus/manifest.json
+++ b/custom_components/salus/manifest.json
@@ -4,6 +4,9 @@
   "version": "0.1.0",
   "documentation": "https://github.com/user/salus-ha",
   "requirements": [],
-  "codeowners": ["@user"],
-  "iot_class": "local_polling"
+  "codeowners": [
+    "@user"
+  ],
+  "iot_class": "local_polling",
+  "config_flow": true
 }

--- a/custom_components/salus/sensor.py
+++ b/custom_components/salus/sensor.py
@@ -13,10 +13,10 @@ from . import DOMAIN, SalusDevice
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the Salus room temperature sensors."""
     _LOGGER.info("Setting up Salus room temperature sensors")
-    devices: list[SalusDevice] = hass.data[DOMAIN]["devices"]
+    devices: list[SalusDevice] = hass.data[DOMAIN][entry.entry_id]["devices"]
     sensors = [SalusRoomTemperatureSensor(device) for device in devices]
     async_add_entities(sensors)
 


### PR DESCRIPTION
## Summary
- add config flow to allow UI-based setup
- refactor integration to use config entries and forward platform setup
- register devices so each sensor and thermostat is tied to a device

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5da02ff6c832aac942fbd87d2a320