### PR TITLE
Add config entry support and device registration

### DIFF
--- a/custom_components/salus/__init__.py
+++ b/custom_components/salus/__init__.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import logging
 
+from homeassistant import config_entries
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers.discovery import async_load_platform
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
+import random
 
 DOMAIN = "salus"
 
@@ -49,34 +50,57 @@ class SalusDevice:
             callback()
 
 
+PLATFORMS = ["climate", "sensor"]
+
+
 async def async_setup(hass, config):
     """Set up the Salus integration."""
-    conf = config[DOMAIN]
-    username = conf[CONF_USERNAME]
-    password = conf[CONF_PASSWORD]
+    hass.data.setdefault(DOMAIN, {})
+    if DOMAIN in config:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_IMPORT},
+                data=config[DOMAIN],
+            )
+        )
+    return True
+
+
+async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
+    """Set up Salus from a config entry."""
+    username = entry.data[CONF_USERNAME]
+    password = entry.data[CONF_PASSWORD]
 
     _LOGGER.info("Setting up Salus integration")
     _LOGGER.debug("Configuration username: %s", username)
 
+    device_ids: list[str] | None = entry.data.get("device_ids")
+    if device_ids is None:
+        device_ids = [f"{random.randint(0, 99999999):08d}" for _ in range(4)]
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, "device_ids": device_ids}
+        )
+
     devices = [
-        SalusDevice("device_1", "Salus Device 1"),
-        SalusDevice("device_2", "Salus Device 2"),
-        SalusDevice("device_3", "Salus Device 3"),
-        SalusDevice("device_4", "Salus Device 4"),
+        SalusDevice(device_id, f"Salus Device {index}")
+        for index, device_id in enumerate(device_ids, start=1)
     ]
 
-    hass.data[DOMAIN] = {
+    hass.data[DOMAIN][entry.entry_id] = {
         "devices": devices,
         "username": username,
         "password": password,
     }
 
-    _LOGGER.debug("Creating Salus platforms")
-    hass.async_create_task(
-        async_load_platform(hass, "climate", DOMAIN, {}, config)
-    )
-    hass.async_create_task(
-        async_load_platform(hass, "sensor", DOMAIN, {}, config)
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     _LOGGER.info("Salus integration setup complete")
     return True
+
+
+async def async_unload_entry(hass, entry: config_entries.ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/custom_components/salus/climate.py
+++ b/custom_components/salus/climate.py
@@ -14,10 +14,10 @@ from . import DOMAIN, SalusDevice
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up the Salus climate entity."""
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the Salus climate entity from a config entry."""
     _LOGGER.info("Setting up Salus climate entity")
-    devices: list[SalusDevice] = hass.data[DOMAIN]["devices"]
+    devices: list[SalusDevice] = hass.data[DOMAIN][entry.entry_id]["devices"]
     entities = [SalusThermostat(device) for device in devices]
     async_add_entities(entities)
 
@@ -44,6 +44,7 @@ class SalusThermostat(ClimateEntity):
             "identifiers": {(DOMAIN, self._device.id)},
             "name": self._device.name,
             "manufacturer": "Salus",
+            "serial_number": self._device.id,
         }
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/salus/config_flow.py
+++ b/custom_components/salus/config_flow.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from . import DOMAIN
+
+
+class SalusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for the Salus integration."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict | None = None):
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            return self.async_create_entry(title="Salus", data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_USERNAME): str,
+                vol.Required(CONF_PASSWORD): str,
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
+
+    async def async_step_import(self, user_input: dict):
+        """Handle import from configuration.yaml."""
+        return await self.async_step_user(user_input)

--- a/custom_components/salus/manifest.json
+++ b/custom_components/salus/manifest.json
@@ -4,6 +4,9 @@
   "version": "0.1.0",
   "documentation": "https://github.com/user/salus-ha",
   "requirements": [],
-  "codeowners": ["@user"],
-  "iot_class": "local_polling"
+  "codeowners": [
+    "@user"
+  ],
+  "iot_class": "local_polling",
+  "config_flow": true
 }

--- a/custom_components/salus/sensor.py
+++ b/custom_components/salus/sensor.py
@@ -13,10 +13,10 @@ from . import DOMAIN, SalusDevice
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the Salus room temperature sensors."""
     _LOGGER.info("Setting up Salus room temperature sensors")
-    devices: list[SalusDevice] = hass.data[DOMAIN]["devices"]
+    devices: list[SalusDevice] = hass.data[DOMAIN][entry.entry_id]["devices"]
     sensors = [SalusRoomTemperatureSensor(device) for device in devices]
     async_add_entities(sensors)
 
@@ -52,4 +52,5 @@ class SalusRoomTemperatureSensor(SensorEntity):
             "identifiers": {(DOMAIN, self._device.id)},
             "name": self._device.name,
             "manufacturer": "Salus",
+            "serial_number": self._device.id,
         }


### PR DESCRIPTION
## Summary
- add config flow to allow UI-based setup
- refactor integration to use config entries and forward platform setup
- register devices so each sensor and thermostat is tied to a device
- persist randomly generated 8-digit device IDs to prevent duplicate devices

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5da02ff6c832aac942fbd87d2a320