### PR TITLE
Add options flow with reload support

### DIFF
--- a/custom_components/salus/__init__.py
+++ b/custom_components/salus/__init__.py
@@ -69,8 +69,8 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry: config_entries.ConfigEntry):
     """Set up Salus from a config entry."""
-    username = entry.data[CONF_USERNAME]
-    password = entry.data[CONF_PASSWORD]
+    username = entry.options.get(CONF_USERNAME, entry.data[CONF_USERNAME])
+    password = entry.options.get(CONF_PASSWORD, entry.data[CONF_PASSWORD])
 
     _LOGGER.info("Setting up Salus integration")
     _LOGGER.debug("Configuration username: %s", username)

--- a/custom_components/salus/config_flow.py
+++ b/custom_components/salus/config_flow.py
@@ -4,6 +4,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
 
 from . import DOMAIN
 
@@ -30,3 +31,45 @@ class SalusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, user_input: dict):
         """Handle import from configuration.yaml."""
         return await self.async_step_user(user_input)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry):
+        """Return the options flow for this handler."""
+        return SalusOptionsFlow(config_entry)
+
+
+class SalusOptionsFlow(config_entries.OptionsFlow):
+    """Handle Salus options."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize Salus options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input: dict | None = None):
+        """Manage Salus options."""
+        current = {
+            CONF_USERNAME: self.config_entry.options.get(
+                CONF_USERNAME, self.config_entry.data[CONF_USERNAME]
+            ),
+            CONF_PASSWORD: self.config_entry.options.get(
+                CONF_PASSWORD, self.config_entry.data[CONF_PASSWORD]
+            ),
+        }
+        if user_input is not None:
+            reload_requested = user_input.pop("reload", False)
+            if reload_requested or user_input != current:
+                self.hass.async_create_task(
+                    self.hass.config_entries.async_reload(self.config_entry.entry_id)
+                )
+            return self.async_create_entry(title="", data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_USERNAME, default=current[CONF_USERNAME]): str,
+                vol.Required(CONF_PASSWORD, default=current[CONF_PASSWORD]): str,
+                vol.Optional("reload", default=False): bool,
+            }
+        )
+
+        return self.async_show_form(step_id="init", data_schema=data_schema)


### PR DESCRIPTION
## Summary
- allow configuring username and password through options flow
- add option to reload integration from options
- use updated credentials from options when setting up

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6fbaff890832a8bb5f200ed8163af