### PR TITLE
Integrate Salus login and token handling

### DIFF
--- a/custom_components/salus/sensor.py
+++ b/custom_components/salus/sensor.py
@@ -17,7 +17,9 @@ async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the Salus room temperature sensors."""
     _LOGGER.info("Setting up Salus room temperature sensors")
     devices: list[SalusDevice] = hass.data[DOMAIN][entry.entry_id]["devices"]
+    token: str = hass.data[DOMAIN][entry.entry_id]["token"]
     sensors = [SalusRoomTemperatureSensor(device) for device in devices]
+    sensors.append(SalusTokenSensor(token))
     async_add_entities(sensors)
 
 
@@ -54,3 +56,21 @@ class SalusRoomTemperatureSensor(SensorEntity):
             "manufacturer": "Salus",
             "serial_number": self._device.id,
         }
+
+
+class SalusTokenSensor(SensorEntity):
+    """Sensor exposing the security token."""
+
+    _attr_icon = "mdi:key"
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+        self._attr_name = "Salus Security Token"
+
+    @property
+    def unique_id(self) -> str:
+        return "salus_security_token"
+
+    @property
+    def native_value(self) -> str:
+        return self._token


### PR DESCRIPTION
## Summary
- Use Salus API to log in once, obtain a security token and parse device list
- Store token and device details for Home Assistant and expose security token as a sensor

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c721f138f0832a886e948276c260cc