### PR TITLE
feat: add hvac mode support

### DIFF
--- a/custom_components/salus/climate.py
+++ b/custom_components/salus/climate.py
@@ -66,6 +66,9 @@ class SalusThermostat(ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         _LOGGER.info("Setting HVAC mode to %s", hvac_mode)
+        await self.hass.async_add_executor_job(
+            self._api.set_hvac_mode, self._device.id, hvac_mode.value
+        )
         self._device.hvac_mode = hvac_mode
         self._device._notify()
 

--- a/custom_components/salus/salus.py
+++ b/custom_components/salus/salus.py
@@ -250,3 +250,17 @@ class Salus:
         }
         response = requests.post(url, data=payload)
         return response
+
+    # Set the HVAC mode (on/off) for the device
+    def set_hvac_mode(self, dev_id, hvac_mode):
+        url = "https://salus-it500.com/includes/set.php"
+        payload = {
+            'token': self.token,
+            'devId': dev_id,
+        }
+
+        # Salus API expects 1 for on (heat) and 0 for off
+        payload['power'] = 1 if str(hvac_mode).lower() != 'off' else 0
+
+        response = requests.post(url, data=payload)
+        return response


### PR DESCRIPTION
## Summary
- allow thermostat to switch between heat and off modes
- expose HVAC mode change via API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c728f97ea4832aa0a2829a6187e19c